### PR TITLE
Put the Adapters image up there and remove the logo

### DIFF
--- a/newsletters/18-12-15-27.md
+++ b/newsletters/18-12-15-27.md
@@ -17,12 +17,11 @@ This week:
 
 -
 
-[![Adaptors](18-12-15-adaptorslogo.png)](http://www.theadaptors.org/)
+[![Assisting evolution](18-12-2015-adaptors-podcastlink.png)](http://www.theadaptors.org/)
 
 # [This awesome podcast tells us about assisted evolution](http://www.theadaptors.org/)
-We are huge fans 🙌🏻 of The Adaptors, a podcast that's about what people do to help the earth adapt to changing climate. Because this week they'd just had their last episode of the season we tip you Assisting Evolution:   
 
-[![Assisting evolution](18-12-2015-adaptors-podcastlink.png)](http://www.theadaptors.org/)
+We are huge fans 🙌🏻 of The Adaptors, a podcast that's about what people do to help the earth adapt to changing climate. Because this week they'd just had their last episode of the season we tip you Assisting Evolution.
 
 Assited Evolution is a brand spanking new 💥 term of describing the activity of helping nature to evolve in to super survivors. This episodes is about the amazing world of corals. Now usually future of corals are described in a very grim way. These scientists are ecxualy doing realy interesting stuff to help corals adapting to the ever changing environment. Creating Super Corals 💪🏼, why not!
 


### PR DESCRIPTION
The logo was a little big while the linking immage is a better headliner I think, plus I think it might be bit weird to be greeted by something that is so clearly a logo as the first thing
